### PR TITLE
Corrected invalid documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ var compare = require('node-version-compare');
 
 var result = compare('1.0.0', '1.0.1');                     // result = -1
     result = compare('10.2.0-alpha.1', '10.2.0-alpha.1');   // result = 0
-    result = compare('10.2.0-alpha', '10.2.0-beta');        // result = 1
+    result = compare('10.2.0-beta', '10.2.0-alpha');        // result = 1
     result = compare('3.1.1-1', '3.1.1-2');                 // result = -1
 ```


### PR DESCRIPTION
This statement in the documentation is invalid:
`compare('10.2.0-alpha', '10.2.0-beta');        // result = 1`

This PR proposes the alternative:
`compare('10.2.0-beta', '10.2.0-alpha');        // result = 1`