### PR TITLE
fix: convert input version params into strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-
 function compare(v1, v2) {
+  v1 = `${v1}`;
+  v2 = `${v2}`;
+  
   var flag1 = v1.indexOf('-') > -1;
   var flag2 = v2.indexOf('-') > -1;
   var arr1 = split(flag1, v1);
@@ -31,6 +33,8 @@ function compare(v1, v2) {
 }
 
 function split(flag, version) {
+  version = `${version}`;
+  
   var result = [];
   if (flag) {
     var tail = version.split('-')[1];
@@ -51,5 +55,3 @@ function convertToNumber(arr) {
 }
 
 module.exports = compare;
-
-

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+'use strict';
+
 function compare(v1, v2) {
-  v1 = `${v1}`;
-  v2 = `${v2}`;
-  
+  v1 = v1 + '';
+  v2 = v2 + '';
+
   var flag1 = v1.indexOf('-') > -1;
   var flag2 = v2.indexOf('-') > -1;
   var arr1 = split(flag1, v1);
@@ -13,28 +15,34 @@ function compare(v1, v2) {
     // 1.0.0 > 1.0.0-beta.2
     if (i === 3 && (arr1[i] === undefined || arr2[i] === undefined)) {
       if (arr1[i] === undefined && isNaN(arr2[i])) {
-        return 1
-      } else if (isNaN(arr1[i]) && arr2[i] === undefined) {
-        return -1;
+        return 1;
+      } else {
+        if (isNaN(arr1[i]) && arr2[i] === undefined) {
+          return -1;
+        }
       }
     }
     if (arr1[i] === undefined) {
-      return -1
-    } else if (arr2[i] === undefined) {
-      return 1
+      return -1;
+    } else {
+      if (arr2[i] === undefined) {
+        return 1;
+      }
     }
     if (arr1[i] > arr2[i]) {
-      return 1
-    } else if (arr1[i] < arr2[i]) {
-      return -1
+      return 1;
+    } else {
+      if (arr1[i] < arr2[i]) {
+        return -1;
+      }
     }
   }
   return 0;
 }
 
 function split(flag, version) {
-  version = `${version}`;
-  
+  version = version + '';
+
   var result = [];
   if (flag) {
     var tail = version.split('-')[1];

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
+'use strict';
+
 var should = require('should');
 var compare = require('../index');
-
 
 describe('index.js', function () {
   it('1.0.0 < 1.0.1', function () {
@@ -41,7 +42,7 @@ describe('index.js', function () {
 
   it('0.0.0 == 0.0.0', function () {
     compare('0.0.0', '0.0.0').should.equal(0);
-  })
+  });
 
   it('9.178.1350-beta.66.0.183.99999 == 9.178.1350-beta.66.0.183.99999', function () {
     compare('9.178.1350-beta.66.0.183.99999', '9.178.1350-beta.66.0.183.99999').should.equal(0);
@@ -51,4 +52,22 @@ describe('index.js', function () {
     compare('1.0.0', '1.0.0-beta.2').should.equal(1);
   });
 
-})
+  describe('Test input values as numbers', function () {
+    it('1 == "1"', function () {
+      compare(1, '1').should.equal(0);
+    });
+
+    it('"1" == 1', function () {
+      compare('1', 1).should.equal(0);
+    });
+
+    it('"1.1" == 1.1', function () {
+      compare('1.1', 1.1).should.equal(0);
+    });
+
+    it('1.1 == "1.1"', function () {
+      compare(1.1, '1.1').should.equal(0);
+    });
+  });
+
+});


### PR DESCRIPTION
Tested with node@14

I think, nodeJS convert versions like "11" always to numbers..

And then we have this error:

```
compare ->  11 8.0
v1.indexOf is not a function
```

with fix in compare() function 

```
compare ->  11 8.0
split( false ,  11 )
version.split is not a function
```